### PR TITLE
fix(aws): missing verb at interface.

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -44,6 +44,8 @@ func (plugin AwsPlugin) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	switch req.Method {
 	case http.MethodPut:
 		plugin.put(rw, req)
+	case http.MethodPost:
+		plugin.post(rw, req)
 	case http.MethodGet:
 		plugin.get(rw, req)
 	default:
@@ -60,6 +62,17 @@ func (plugin *AwsPlugin) put(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 	resp, err := plugin.service.Put(req.URL.Path[1:], payload, req.Header.Get("Content-Type"), rw)
+	handleResponse(resp, err, rw)
+}
+
+func (plugin *AwsPlugin) post(rw http.ResponseWriter, req *http.Request) {
+	payload, err := io.ReadAll(req.Body)
+	if err != nil {
+		rw.WriteHeader(http.StatusNotAcceptable)
+		log.Error(fmt.Sprintf("Reading body failed: %s", err.Error()))
+		return
+	}
+	resp, err := plugin.service.Post(req.URL.Path[1:], payload, req.Header.Get("Content-Type"), rw)
 	handleResponse(resp, err, rw)
 }
 


### PR DESCRIPTION
This is a bit different than the og version so I missed this until I could get it running in aws and figure out why traffic wasn't getting to it.
Can publish this as a patch version 1.1.1 if it passes the yaegi tests, which it should no problem.
