### PR TITLE
Add support for query params on GET requests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,8 +14,8 @@ jobs:
   build:
     name: build
     env:
-      GO_VERSION: 1.21.3
-      GOLANGCI_LINT_VERSION: v1.55.2
+      GO_VERSION: 1.25.1
+      GOLANGCI_LINT_VERSION: v2.4.0
       CGO_ENABLED: 0
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
 
     # https://github.com/marketplace/actions/run-golangci-lint
     - name: Install golangci-lint ${{ env.GOLANGCI_LINT_VERSION }}
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v8
       with:
         version: ${{ env.GOLANGCI_LINT_VERSION }}
         args: "--help"

--- a/aws.go
+++ b/aws.go
@@ -86,8 +86,8 @@ func (plugin *AwsPlugin) get(rw http.ResponseWriter, req *http.Request) {
 func handleResponse(resp []byte, reqErr error, rw http.ResponseWriter) {
 	if reqErr != nil {
 		rw.WriteHeader(http.StatusInternalServerError)
-		http.Error(rw, fmt.Sprintf("Put error: %s", reqErr.Error()), http.StatusInternalServerError)
-		log.Error(reqErr.Error())
+		http.Error(rw, fmt.Sprintf("Traefik AWS Plugin error: %s", reqErr.Error()), http.StatusInternalServerError)
+		log.Error("Traefik AWS Plugin error:" + reqErr.Error())
 		return
 	}
 	rw.WriteHeader(http.StatusOK)

--- a/aws.go
+++ b/aws.go
@@ -3,18 +3,20 @@ package traefik_aws_plugin
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
 	"github.com/bluecatengineering/traefik-aws-plugin/ecs"
 	"github.com/bluecatengineering/traefik-aws-plugin/local"
 	"github.com/bluecatengineering/traefik-aws-plugin/log"
 	"github.com/bluecatengineering/traefik-aws-plugin/s3"
-	"io"
-	"net/http"
 )
 
 type Service interface {
 	Put(name string, payload []byte, contentType string, rw http.ResponseWriter) ([]byte, error)
 	Post(name string, payload []byte, contentType string, rw http.ResponseWriter) ([]byte, error)
-	Get(name string, rw http.ResponseWriter) ([]byte, error)
+	Get(name string, params url.Values, rw http.ResponseWriter) ([]byte, error)
 }
 
 type Config struct {
@@ -77,7 +79,7 @@ func (plugin *AwsPlugin) post(rw http.ResponseWriter, req *http.Request) {
 }
 
 func (plugin *AwsPlugin) get(rw http.ResponseWriter, req *http.Request) {
-	resp, err := plugin.service.Get(req.URL.Path[1:], rw)
+	resp, err := plugin.service.Get(req.URL.Path[1:], req.URL.Query(), rw)
 	handleResponse(resp, err, rw)
 }
 

--- a/local/local.go
+++ b/local/local.go
@@ -3,6 +3,7 @@ package local
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/bluecatengineering/traefik-aws-plugin/log"
@@ -40,7 +41,7 @@ func (local *Local) Post(path string, payload []byte, contentType string, rw htt
 	return local.Put(path+"/"+uuid.NewString(), payload, contentType, rw)
 }
 
-func (local *Local) Get(name string, _ http.ResponseWriter) ([]byte, error) {
+func (local *Local) Get(name string, params url.Values, _ http.ResponseWriter) ([]byte, error) {
 	filePath := fmt.Sprintf("%s/%s", local.directory, name)
 	payload, err := os.ReadFile(filePath)
 	if err != nil {

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -40,6 +40,10 @@ func New(bucket, prefix, region string, timeoutSeconds int, creds *ecs.Credentia
 
 func (s3 *S3) request(httpMethod string, name string, payload []byte, params url.Values, contentType string, rw http.ResponseWriter) ([]byte, error) {
 	uri := s3.bucketUri + s3.prefix + "/" + name
+	if len(params) > 0 {
+		uri += "?" + params.Encode()
+	}
+
 	var payloadReader io.Reader = nil
 	if payload != nil {
 		payloadReader = bytes.NewReader(payload)
@@ -49,8 +53,6 @@ func (s3 *S3) request(httpMethod string, name string, payload []byte, params url
 		log.Error(err.Error())
 		return nil, err
 	}
-	req.URL.RawQuery = params.Encode()
-	log.Debug("Outgoing S3 request: " + req.URL.String())
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(s3.timeoutSeconds)*time.Second)
 	if cancel != nil {
 		defer cancel()
@@ -67,6 +69,7 @@ func (s3 *S3) request(httpMethod string, name string, payload []byte, params url
 		return nil, err
 	}
 	if resp.StatusCode > 299 {
+		rw.WriteHeader(resp.StatusCode)
 		return nil, fmt.Errorf(cr.RequestString())
 	}
 	response, err := io.ReadAll(resp.Body)

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -50,6 +50,7 @@ func (s3 *S3) request(httpMethod string, name string, payload []byte, params url
 		return nil, err
 	}
 	req.URL.RawQuery = params.Encode()
+	log.Debug("Outgoing S3 request: " + req.URL.String())
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(s3.timeoutSeconds)*time.Second)
 	if cancel != nil {
 		defer cancel()

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -3,6 +3,7 @@ package s3
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -70,7 +71,7 @@ func (s3 *S3) request(httpMethod string, name string, payload []byte, params url
 	}
 	if resp.StatusCode > 299 {
 		rw.WriteHeader(resp.StatusCode)
-		return nil, fmt.Errorf(cr.RequestString())
+		return nil, errors.New(cr.RequestString())
 	}
 	response, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/bluecatengineering/traefik-aws-plugin/ecs"
@@ -37,7 +38,7 @@ func New(bucket, prefix, region string, timeoutSeconds int, creds *ecs.Credentia
 	}
 }
 
-func (s3 *S3) request(httpMethod string, name string, payload []byte, contentType string, rw http.ResponseWriter) ([]byte, error) {
+func (s3 *S3) request(httpMethod string, name string, payload []byte, params url.Values, contentType string, rw http.ResponseWriter) ([]byte, error) {
 	uri := s3.bucketUri + s3.prefix + "/" + name
 	var payloadReader io.Reader = nil
 	if payload != nil {
@@ -48,6 +49,7 @@ func (s3 *S3) request(httpMethod string, name string, payload []byte, contentTyp
 		log.Error(err.Error())
 		return nil, err
 	}
+	req.URL.RawQuery = params.Encode()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(s3.timeoutSeconds)*time.Second)
 	if cancel != nil {
 		defer cancel()
@@ -77,15 +79,15 @@ func (s3 *S3) request(httpMethod string, name string, payload []byte, contentTyp
 }
 
 func (s3 *S3) Put(name string, payload []byte, contentType string, rw http.ResponseWriter) ([]byte, error) {
-	return s3.request(http.MethodPut, name, payload, contentType, rw)
+	return s3.request(http.MethodPut, name, payload, nil, contentType, rw)
 }
 
 func (s3 *S3) Post(path string, payload []byte, contentType string, rw http.ResponseWriter) ([]byte, error) {
 	return s3.Put(path+"/"+uuid.NewString(), payload, contentType, rw)
 }
 
-func (s3 *S3) Get(name string, rw http.ResponseWriter) ([]byte, error) {
-	return s3.request(http.MethodGet, name, nil, "", rw)
+func (s3 *S3) Get(name string, params url.Values, rw http.ResponseWriter) ([]byte, error) {
+	return s3.request(http.MethodGet, name, nil, params, "", rw)
 }
 
 func copyHeader(dst, src http.Header) {

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -5,12 +5,13 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"github.com/bluecatengineering/traefik-aws-plugin/ecs"
 	"net/http"
 	"net/url"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/bluecatengineering/traefik-aws-plugin/ecs"
 )
 
 // https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html
@@ -23,14 +24,14 @@ type CanonRequest struct {
 	// V4 data
 	httpMethod  string
 	date        string
-	queryParams map[string]string
+	queryParams url.Values
 	amzHeaders  map[string]string
 	canonUri    string
 }
 
 // https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html#create-canonical-request
 func (cr *CanonRequest) RequestString() string {
-	queryString := canonString(cr.queryParams, "=", "&", true)
+	queryString := cr.queryParams.Encode()
 	headers := canonString(cr.amzHeaders, ":", "\n", false)
 	signedHeaders := strings.Join(sortedKeys(cr.amzHeaders), ";")
 	hashedPayload := cr.amzHeaders["x-amz-content-sha256"]
@@ -128,6 +129,7 @@ func updateCanonRequest(req *http.Request, cr *CanonRequest) *CanonRequest {
 	if req.URL.Path != "" {
 		cr.canonUri = strings.TrimSpace(req.URL.Path)
 	}
+	cr.queryParams = req.URL.Query()
 	return cr
 }
 

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -32,7 +32,7 @@ type CanonRequest struct {
 // https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html#create-canonical-request
 func (cr *CanonRequest) RequestString() string {
 	queryString := cr.queryParams.Encode()
-	headers := canonString(cr.amzHeaders, ":", "\n", false)
+	headers := canonString(cr.amzHeaders, ":", "\n")
 	signedHeaders := strings.Join(sortedKeys(cr.amzHeaders), ";")
 	hashedPayload := cr.amzHeaders["x-amz-content-sha256"]
 	return fmt.Sprintf("%s\n%s\n%s\n%s\n\n%s\n%s", cr.httpMethod, cr.canonUri, queryString, headers, signedHeaders, hashedPayload)
@@ -133,7 +133,7 @@ func updateCanonRequest(req *http.Request, cr *CanonRequest) *CanonRequest {
 	return cr
 }
 
-func canonString(in map[string]string, sep string, inter string, encoding bool) string {
+func canonString(in map[string]string, sep string, inter string) string {
 	var c string
 	keys := make([]string, 0, len(in))
 	for k := range in {
@@ -144,11 +144,7 @@ func canonString(in map[string]string, sep string, inter string, encoding bool) 
 		if c != "" {
 			c = c + inter
 		}
-		if encoding {
-			c = c + fmt.Sprintf("%s%s%s", url.QueryEscape(k), sep, url.QueryEscape(in[k]))
-		} else {
-			c = c + fmt.Sprintf("%s%s%s", k, sep, in[k])
-		}
+		c = c + fmt.Sprintf("%s%s%s", k, sep, in[k])
 	}
 	return c
 }

--- a/signer/signer_test.go
+++ b/signer/signer_test.go
@@ -3,9 +3,11 @@ package signer
 import (
 	"bytes"
 	"fmt"
-	"github.com/bluecatengineering/traefik-aws-plugin/ecs"
 	"net/http"
+	"net/url"
 	"testing"
+
+	"github.com/bluecatengineering/traefik-aws-plugin/ecs"
 )
 
 func TestCanonRequestV4(t *testing.T) {
@@ -15,6 +17,28 @@ func TestCanonRequestV4(t *testing.T) {
 		expectedAuthHeader string
 		name               string
 	}{
+		{
+			name:               "get versioned object request",
+			expectedSig:        "507d483a5b2823c61593ed3b1db476ba3568e4b82c1c7005441ba406e83699cd",
+			expectedAuthHeader: "AWS4-HMAC-SHA256 Credential=KEY/20130524/us-east-1/s3/aws4_request,SignedHeaders=host;range;x-amz-content-sha256;x-amz-date,Signature=507d483a5b2823c61593ed3b1db476ba3568e4b82c1c7005441ba406e83699cd",
+			cr: &CanonRequest{
+				Creds: &ecs.Credentials{
+					AccessSecretKey: "SECRET",
+					AccessKeyId:     "KEY",
+				},
+				httpMethod: "GET",
+				date:       "20130524T000000Z",
+				Region:     "us-east-1",
+				Service:    "s3",
+				canonUri:   "/test.txt",
+				amzHeaders: map[string]string{
+					"host":                 "examplebucket.s3.amazonaws.com",
+					"range":                "bytes=0-9",
+					"x-amz-content-sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+					"x-amz-date":           "20130524T000000Z",
+				},
+			},
+		},
 		{
 			name:               "get object request",
 			expectedSig:        "5e00930a4878798235e8c6527ca3cfd780b87b472de204b22a07fbc10841e751",
@@ -62,6 +86,10 @@ func TestCanonRequestV4(t *testing.T) {
 		},
 	}
 
+	values := make(url.Values)
+	values.Add("versionId", "abcdef")
+	testCases[0].cr.queryParams = values
+
 	for _, tt := range testCases {
 		signature := tt.cr.SignatureV4()
 		authHeader := tt.cr.AuthHeader()
@@ -85,6 +113,7 @@ func TestSignerV4(t *testing.T) {
 	}
 
 	r1, _ := http.NewRequest(http.MethodPut, "https://examplebucket.s3.amazonaws.com/text/test/file.text", bytes.NewReader([]byte("")))
+	r2, _ := http.NewRequest(http.MethodGet, "https://examplebucket.s3.amazonaws.com/text/test/file.text?versionId=abcdef", nil)
 
 	testCases := []struct {
 		name     string
@@ -96,11 +125,16 @@ func TestSignerV4(t *testing.T) {
 			expected: "hello",
 			request:  r1,
 		},
+		{
+			name:     "basic",
+			expected: "hello",
+			request:  r2,
+		},
 	}
 
 	for _, tt := range testCases {
-		r1.Header.Set("Content-Type", "application/json")
-		r1.Header.Set("Host", r1.URL.Host)
+		tt.request.Header.Set("Content-Type", "application/json")
+		tt.request.Header.Set("Host", tt.request.URL.Host)
 		cr := CreateCanonRequest(tt.request, make([]byte, 0), *crTemplate)
 		fmt.Printf("%v\n", cr.AuthHeader())
 		fmt.Printf("%v\n", cr.StringToSignV4())


### PR DESCRIPTION
1. Updated the S3 GET code path to pass query params through
2. Update canonical request to include query params in signed requests
3. Added test cases with query params to signer tests
4. Updated build actions:
    - Upgraded golang version
    - Upgraded linter version
    - Upgraded linter action version 